### PR TITLE
Update module versions for terraform 0.12 readiness.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,10 @@ module "aws-autoscaling_bastion_asg" {
 module "bastion" {
   source = "github.com/traveloka/terraform-aws-iam-role.git//modules/instance?ref=v1.0.1"
 
-  service_name = "${var.service_name}"
-  cluster_role = "${local.role}"
+  cluster_role   = "${local.role}"
+  service_name   = "${var.service_name}"
+  environment    = "${var.environment}"
+  product_domain = "${var.product_domain}"
 }
 
 # Security Groups

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # ASG
 module "aws-autoscaling_bastion_asg" {
-  source = "github.com/traveloka/terraform-aws-autoscaling?ref=v0.1.5"
+  source = "github.com/traveloka/terraform-aws-autoscaling?ref=v0.2.0-simple_swap"
 
   product_domain = "${var.product_domain}"
   service_name   = "${var.service_name}"
@@ -33,7 +33,7 @@ module "aws-autoscaling_bastion_asg" {
 
 # Instance Role
 module "bastion" {
-  source = "github.com/traveloka/terraform-aws-iam-role.git//modules/instance?ref=v0.6.0"
+  source = "github.com/traveloka/terraform-aws-iam-role.git//modules/instance?ref=v1.0.1"
 
   service_name = "${var.service_name}"
   cluster_role = "${local.role}"


### PR DESCRIPTION
Upgrade terraform-aws-iam-role from 0.6.0 to 1.0.1 (no longer forces aws provider to be version ~> 1.14)
Update terrafrom-aws-autoscaling from 0.1.5 to 0.2.0-simple_swap (no longer forces random provider to be version ~> 1)

Closes https://github.com/traveloka/terraform-aws-tvlk-bastion/issues/7