### PR TITLE
Add support for private Elasticsearch clusters

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,11 @@ output "shared_sg_redis_id" {
   value       = "${aws_security_group.redis.id}"
 }
 
+output "shared_sg_elasticsearch_id" {
+  description = "id of shared security group for elasticsearch."
+  value       = "${aws_security_group.elasticsearch.id}"
+}
+
 output "instance_role_name" {
   description = "role name for the instances."
   value       = "${module.bastion.role_name}"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Resolve #19 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-tvlk-bastion/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* feature: Add support for private Elasticsearch clusters

```

***

Output from `terraform plan` command from changes you propose. Output below truncated to only contain plan output for new resources.

```
$ terraform plan
...
+ module.this.aws_security_group.elasticsearch
      id:                             <computed>
      arn:                            <computed>
      description:                    "tsibstn-elasticsearch security group"
      egress.#:                       <computed>
      ingress.#:                      <computed>
      name:                           "tsibstn-elasticsearch"
      owner_id:                       <computed>
      revoke_rules_on_delete:         "false"
      tags.%:                         "6"
      tags.Description:               "Security group for tsibstn-elasticsearch"
      tags.Environment:               "staging"
      tags.ManagedBy:                 "terraform"
      tags.Name:                      "tsibstn-elasticsearch"
      tags.ProductDomain:             "tsi"
      tags.Service:                   "tsibstn"
      vpc_id:                         "vpc-123456789"
...
+ module.this.aws_security_group_rule.egress_from_bastion_to_elasticsearch_443
      id:                             <computed>
      description:                    "Egress from tsibstn-bastion to tsibstn-elasticsearch in 443"
      from_port:                      "443"
      protocol:                       "tcp"
      security_group_id:              "${aws_security_group.bastion.id}"
      self:                           "false"
      source_security_group_id:       "${aws_security_group.elasticsearch.id}"
      to_port:                        "443"
      type:                           "egress"
...
+ module.this.aws_security_group_rule.ingress_from_bastion_to_elasticsearch_443
      id:                             <computed>
      description:                    "Ingress from tsibstn-bastion to tsibstn-elasticsearch in 443"
      from_port:                      "443"
      protocol:                       "tcp"
      security_group_id:              "${aws_security_group.elasticsearch.id}"
      self:                           "false"
      source_security_group_id:       "${aws_security_group.bastion.id}"
      to_port:                        "443"
      type:                           "ingress"

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
