### PR TITLE
Support additional tags in Bastion ASG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ module "aws-autoscaling_bastion_asg" {
   asg_default_cooldown          = "${var.asg_default_cooldown}"
   asg_health_check_type         = "${var.asg_health_check_type}"
   asg_wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
-  additional_asg_tags           = "${var.asg_tags}"
+  asg_tags                      = "${var.additional_asg_tags}"
 }
 
 # Instance Role

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ module "aws-autoscaling_bastion_asg" {
   asg_default_cooldown          = "${var.asg_default_cooldown}"
   asg_health_check_type         = "${var.asg_health_check_type}"
   asg_wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
-  asg_tags                      = "${var.asg_tags}"
+  additional_asg_tags           = "${var.asg_tags}"
 }
 
 # Instance Role

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "aws-autoscaling_bastion_asg" {
   asg_default_cooldown          = "${var.asg_default_cooldown}"
   asg_health_check_type         = "${var.asg_health_check_type}"
   asg_wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
+  asg_tags                      = "${var.asg_tags}"
 }
 
 # Instance Role

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,9 @@ variable "lc_user_data" {
   default     = " "
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
+
+variable "asg_tags" {
+  type        = "list"
+  default     = []
+  description = "The created ASG (and spawned instances) will have these tags, merged over the default"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,7 @@ variable "lc_user_data" {
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
 
-variable "asg_tags" {
+variable "additional_asg_tags" {
   type        = "list"
   default     = []
   description = "The created ASG (and spawned instances) will have these tags, merged over the default"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes https://github.com/traveloka/terraform-aws-tvlk-bastion/issues/25

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-tvlk-bastion/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Optional additional ASG tags list that can be used for cost tracking purposes. 

FEATURES:

* New `additional_asg_tags` variable to submit extra tags. 

ENHANCEMENTS:

* None

BUG FIXES:

* None
```

```
$ terraform plan

Terraform Plan changes when a Team tag is passed to this module. 

 ~ module.bastion.module.aws-autoscaling_bastion_asg.aws_autoscaling_group.main
      tags.#:                     "8" => "9"
      tags.8.%:                   "0" => "3"
      tags.8.key:                 "" => "Team"
      tags.8.propagate_at_launch: "" => "1"
      tags.8.value:               "" => "<team-tag>"
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
